### PR TITLE
Fix order detection for compound surnames in batch analysis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sinonym"
-version = "0.2.3"
+version = "0.2.4"
 description = "Chinese Name Detection and Normalization Module"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinonym/detector.py
+++ b/sinonym/detector.py
@@ -495,6 +495,15 @@ class ChineseNameDetector:
                     is_surname_first_in_this_order = list(order_tokens[:k]) == surname_tokens
                     is_surname_last_in_this_order = list(order_tokens[-k:]) == surname_tokens
 
+                    # Compound surname fallback: surname_tokens may be sub-tokens
+                    # of a single original token (e.g. ['Ou','yang'] from 'Ouyang')
+                    if not is_surname_first_in_this_order and not is_surname_last_in_this_order:
+                        joined_surname = "".join(surname_tokens).lower()
+                        if order_tokens[0].lower() == joined_surname:
+                            is_surname_first_in_this_order = True
+                        elif order_tokens[-1].lower() == joined_surname:
+                            is_surname_last_in_this_order = True
+
                     if used_original:
                         original_is_given_first = is_surname_last_in_this_order
                     else:

--- a/sinonym/services/batch_analysis.py
+++ b/sinonym/services/batch_analysis.py
@@ -253,6 +253,15 @@ class BatchAnalysisService:
         if surname_tokens[-1] == original_tokens[-1]:
             return NameFormat.GIVEN_FIRST
 
+        # Compound surname: surname_tokens may be sub-tokens of a single
+        # original token (e.g. ['Ou','yang'] from 'Ouyang').
+        # Reconstruct and check against original tokens.
+        joined_surname = "".join(surname_tokens).lower()
+        if original_tokens[0].lower() == joined_surname:
+            return NameFormat.SURNAME_FIRST
+        if original_tokens[-1].lower() == joined_surname:
+            return NameFormat.GIVEN_FIRST
+
         # Default to surname-first for unclear cases
         return NameFormat.SURNAME_FIRST
 


### PR DESCRIPTION
_determine_parse_format failed to match compound surnames (e.g. Ouyang, Huangfu) where surname_tokens are sub-tokens of the original input token. Reconstruct joined surname and compare against original tokens as fallback.