### PR TITLE
TIMO: PP-vs-VYS name-order router endpoints (v0.2.9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sinonym"
-version = "0.2.8"
+version = "0.2.9"
 description = "Chinese Name Detection and Normalization Module"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinonym/timo/config.yaml
+++ b/sinonym/timo/config.yaml
@@ -12,7 +12,7 @@ model_variants:
     docker_run_commands: []
   sinonym_routing_v1:
     instance: sinonym.timo.interface.RoutingInstance
-    prediction: sinonym.timo.interface.RoutedPrediction
+    prediction: sinonym.timo.interface.RoutedPaperPrediction
     predictor: sinonym.timo.interface.RoutingPredictor
     predictor_config: sinonym.timo.interface.PredictorConfig
     artifacts_s3_path: null

--- a/sinonym/timo/config.yaml
+++ b/sinonym/timo/config.yaml
@@ -10,3 +10,13 @@ model_variants:
     cuda: False
     integration_test: sinonym.timo.integration_test.TestIntegration
     docker_run_commands: []
+  sinonym_routing_v1:
+    instance: sinonym.timo.interface.RoutingInstance
+    prediction: sinonym.timo.interface.RoutedPrediction
+    predictor: sinonym.timo.interface.RoutingPredictor
+    predictor_config: sinonym.timo.interface.PredictorConfig
+    artifacts_s3_path: null
+    python_version: "3.10"
+    cuda: False
+    integration_test: sinonym.timo.integration_test.TestRoutingIntegration
+    docker_run_commands: []

--- a/sinonym/timo/integration_test.py
+++ b/sinonym/timo/integration_test.py
@@ -1,6 +1,14 @@
 import unittest
 
-from sinonym.timo.interface import Instance, Prediction, Predictor, PredictorConfig
+from sinonym.timo.interface import (
+    Instance,
+    Prediction,
+    Predictor,
+    PredictorConfig,
+    RoutedPrediction,
+    RoutingInstance,
+    RoutingPredictor,
+)
 
 
 class TestIntegration(unittest.TestCase):
@@ -67,3 +75,37 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(len(result.name_order_evidence), 2)
         self.assertEqual(result.name_order_evidence[0].raw_name, "Li Wei")
         self.assertEqual(result.name_order_evidence[0].selected_format, "surname_first")
+
+
+class TestRoutingIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.predictor = RoutingPredictor(config=PredictorConfig(), artifacts_dir=".")
+
+    def test_route_with_vys_pool(self):
+        # paper authors must be the leading slice of the pool
+        pp = ["Yue Lin", "Wei Wang"]
+        pool = pp + ["Jun Zhao", "Hui Li"]
+        results = self.predictor.predict_batch([RoutingInstance(pp_names=pp, vys_pool_names=pool)])
+        self.assertEqual(len(results), 2)  # one RoutedPrediction per pp author
+        for r in results:
+            self.assertIsInstance(r, RoutedPrediction)
+            self.assertIn(r.router_prediction, {"pp", "vys", "abstain", "not_person"})
+            self.assertIsNotNone(r.vys)  # vys candidate present when a pool is given
+
+    def test_route_pp_only_fallback(self):
+        results = self.predictor.predict_batch([RoutingInstance(pp_names=["Li Wei"])])
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].vys)  # PP-only fallback: no venue pool
+        self.assertIsNone(results[0].input_order_candidate)
+
+    def test_predict_batch_concatenates_papers(self):
+        instances = [
+            RoutingInstance(pp_names=["Li Wei", "Wang Weiming"]),
+            RoutingInstance(pp_names=["Zhang San"]),
+        ]
+        results = self.predictor.predict_batch(instances)
+        self.assertEqual(len(results), 3)  # 2 + 1 authors, contiguous per paper
+
+    def test_predict_batch_empty(self):
+        self.assertEqual(self.predictor.predict_batch([]), [])

--- a/sinonym/timo/integration_test.py
+++ b/sinonym/timo/integration_test.py
@@ -5,6 +5,7 @@ from sinonym.timo.interface import (
     Prediction,
     Predictor,
     PredictorConfig,
+    RoutedPaperPrediction,
     RoutedPrediction,
     RoutingInstance,
     RoutingPredictor,
@@ -87,8 +88,11 @@ class TestRoutingIntegration(unittest.TestCase):
         pp = ["Yue Lin", "Wei Wang"]
         pool = pp + ["Jun Zhao", "Hui Li"]
         results = self.predictor.predict_batch([RoutingInstance(pp_names=pp, vys_pool_names=pool)])
-        self.assertEqual(len(results), 2)  # one RoutedPrediction per pp author
-        for r in results:
+        self.assertEqual(len(results), 1)  # one prediction per instance (timo 1:1 contract)
+        paper = results[0]
+        self.assertIsInstance(paper, RoutedPaperPrediction)
+        self.assertEqual(len(paper.authors), 2)  # one RoutedPrediction per pp author
+        for r in paper.authors:
             self.assertIsInstance(r, RoutedPrediction)
             self.assertIn(r.router_prediction, {"pp", "vys", "abstain", "not_person"})
             self.assertIsNotNone(r.vys)  # vys candidate present when a pool is given
@@ -96,16 +100,25 @@ class TestRoutingIntegration(unittest.TestCase):
     def test_route_pp_only_fallback(self):
         results = self.predictor.predict_batch([RoutingInstance(pp_names=["Li Wei"])])
         self.assertEqual(len(results), 1)
-        self.assertIsNone(results[0].vys)  # PP-only fallback: no venue pool
-        self.assertIsNone(results[0].input_order_candidate)
+        authors = results[0].authors
+        self.assertEqual(len(authors), 1)
+        self.assertIsNone(authors[0].vys)  # PP-only fallback: no venue pool
+        self.assertIsNone(authors[0].input_order_candidate)
 
-    def test_predict_batch_concatenates_papers(self):
+    def test_predict_batch_is_one_to_one(self):
         instances = [
             RoutingInstance(pp_names=["Li Wei", "Wang Weiming"]),
             RoutingInstance(pp_names=["Zhang San"]),
         ]
         results = self.predictor.predict_batch(instances)
-        self.assertEqual(len(results), 3)  # 2 + 1 authors, contiguous per paper
+        self.assertEqual(len(results), len(instances))  # 1:1, paper boundaries preserved
+        self.assertEqual([len(p.authors) for p in results], [2, 1])
+
+    def test_empty_paper_still_emits_one_prediction(self):
+        # an instance with no authors must not vanish from the output stream
+        results = self.predictor.predict_batch([RoutingInstance(pp_names=[])])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].authors, [])
 
     def test_predict_batch_empty(self):
         self.assertEqual(self.predictor.predict_batch([]), [])

--- a/sinonym/timo/interface.py
+++ b/sinonym/timo/interface.py
@@ -215,6 +215,25 @@ class PPRoutedPrediction(TimoModel):
     pp: Prediction = Field(description="the paper-batch (PP) parse for this author")
 
 
+class RoutingInstance(TimoModel):
+    """One paper's authors for the routing-served variant (`RoutingPredictor.predict_batch`).
+
+    Self-contained per instance (the timo runner feeds one Instance at a time), so each carries
+    its own venue pool. `predict_batch([paper])` returns `len(pp_names)` RoutedPredictions in
+    `pp_names` order.
+    """
+
+    pp_names: list[str] = Field(description="the paper's author names (PP batch); output aligns to this order")
+    vys_pool_names: list[str] | None = Field(
+        default=None,
+        description=(
+            "venue-source-year author pool with the paper's authors as the FIRST len(pp_names) "
+            "entries (same strings/order as pp_names), then the other venue authors. None/empty => "
+            "PP-only routing fallback."
+        ),
+    )
+
+
 class PredictorConfig(BaseSettings):
     pass
 
@@ -317,7 +336,7 @@ class Predictor:
             confidences=[a.confidence for a in batch_result.individual_analyses],
         )
 
-    # ---- timo entrypoint --------------------------------------------------
+    # ---- predict_batch: timo-served entrypoint for sinonym_v1 (flat name->Prediction) ----
 
     def predict_batch(self, instances: list[Instance]) -> list[Prediction]:
         """timo HTTP entrypoint. Analyzes the whole batch jointly.
@@ -400,7 +419,11 @@ class Predictor:
         batch_result = self._detector.analyze_name_batch(names, **self._batch_kwargs(format_threshold, minimum_batch_size))
         return self._to_batch_summary(batch_result)
 
-    # ---- pp-vys routing ---------------------------------------------------
+    # ---- name-order routing (call `route`) --------------------------------
+    # The routing core: `RoutingPredictor.predict_batch` (the sinonym_routing_v1 timo variant)
+    # calls `route` per RoutingInstance; also callable directly by importing Predictor.
+    # Needs per-paper grouping (pp_names + vys_pool_names), which the flat sinonym_v1
+    # predict_batch(List[Instance]) contract can't express — hence the separate variant.
 
     def route_pp_vys(
         self,
@@ -580,3 +603,18 @@ class Predictor:
             )
             for r in self.route_pp(pp_names)
         ]
+
+
+class RoutingPredictor(Predictor):
+    """timo-served routing variant: Instance = one paper, Prediction = per-author RoutedPrediction.
+
+    Wraps `Predictor.route`. Each RoutingInstance yields `len(pp_names)` RoutedPredictions (in
+    pp_names order); the timo runner writes each on its own line, so paper boundaries are the
+    order in which authors are emitted (one instance's authors are contiguous).
+    """
+
+    def predict_batch(self, instances: list[RoutingInstance]) -> list[RoutedPrediction]:  # type: ignore[override]
+        out: list[RoutedPrediction] = []
+        for inst in instances:
+            out.extend(self.route(inst.pp_names, inst.vys_pool_names))
+        return out

--- a/sinonym/timo/interface.py
+++ b/sinonym/timo/interface.py
@@ -266,6 +266,15 @@ class Predictor:
             format_pattern=format_pattern,
         )
 
+    @staticmethod
+    def _routed_name_fields(parsed) -> dict:
+        """given/surname/middle for a routed answer (all None when `parsed` is None)."""
+        return {
+            "given_name": parsed.given_name if parsed else None,
+            "surname": parsed.surname if parsed else None,
+            "middle_name": parsed.middle_name if parsed and parsed.middle_name else None,
+        }
+
     def _to_format_pattern(self, pattern) -> FormatPattern:
         return FormatPattern(
             dominant_format=pattern.dominant_format.value,
@@ -459,6 +468,8 @@ class Predictor:
         from sinonym.coretypes import BatchParseResult
         from sinonym.pipeline.name_order_routing import route_pp_vys_abstain_batches
 
+        if not pp_names:
+            return []
         n = len(pp_names)
         if len(vys_pool_names) < n:
             message = (
@@ -469,8 +480,6 @@ class Predictor:
         if list(vys_pool_names[:n]) != list(pp_names):
             message = "vys_pool_names must start with the paper's authors: vys_pool_names[:len(pp_names)] == pp_names"
             raise ValueError(message)
-        if not pp_names:
-            return []
 
         pp_batch = self._detector.analyze_name_batch(pp_names)
         pool = self._detector.analyze_name_batch(vys_pool_names)
@@ -486,6 +495,8 @@ class Predictor:
         )
         rows = route_pp_vys_abstain_batches(pp_batch, vys_batch)
 
+        # format_pattern is batch-wide (same for every row); build each once and share it —
+        # the candidate Predictions are output DTOs and never mutate it.
         pp_fp = self._to_format_pattern(pp_batch.format_pattern)
         vys_fp = self._to_format_pattern(vys_batch.format_pattern)
         out: list[RoutedPrediction] = []
@@ -514,14 +525,12 @@ class Predictor:
             out.append(
                 RoutedPrediction(
                     success=bool(chosen is not None and chosen.success),
-                    given_name=parsed.given_name if parsed else None,
-                    surname=parsed.surname if parsed else None,
-                    middle_name=(parsed.middle_name if parsed and parsed.middle_name else None),
+                    **self._routed_name_fields(parsed),
                     router_prediction=pred,
                     router_reason=row.get("router_reason", ""),
                     input_order_candidate=ioc,
-                    pp=self._to_prediction(pp_res, format_pattern=pp_fp.copy(deep=True)),
-                    vys=self._to_prediction(vys_res, format_pattern=vys_fp.copy(deep=True)),
+                    pp=self._to_prediction(pp_res, format_pattern=pp_fp),
+                    vys=self._to_prediction(vys_res, format_pattern=vys_fp),
                 )
             )
         return out
@@ -544,6 +553,7 @@ class Predictor:
 
         pp_batch = self._detector.analyze_name_batch(names)
         rows = route_pp_abstain_rows(build_pp_abstain_rows(pp_batch, self._detector))
+        # format_pattern is batch-wide (same for every row); build once and share it.
         pp_fp = self._to_format_pattern(pp_batch.format_pattern)
 
         out: list[PPRoutedPrediction] = []
@@ -553,7 +563,12 @@ class Predictor:
             if pred == "pp":
                 parsed = res.parsed if res.success else None
             elif pred == "abstain":
-                parsed = res.parsed_original_order if res.success else None
+                # Single-batch regime: the "input-order parse" IS the PP-batch parse — there is no
+                # second batch / input_order_candidate to pick (unlike route_pp_vys). res.parsed and
+                # res.parsed_original_order carry the same surname/given (they differ only in the
+                # display `order`, which this endpoint drops), so abstain emits the same name as pp;
+                # the decision differs only as a confidence label.
+                parsed = res.parsed if res.success else None
             elif pred == "not_person":  # valid Route value; emit nothing (pp-abstain router doesn't produce it today)
                 parsed = None
             else:
@@ -562,12 +577,10 @@ class Predictor:
             out.append(
                 PPRoutedPrediction(
                     success=bool(parsed is not None),
-                    given_name=parsed.given_name if parsed else None,
-                    surname=parsed.surname if parsed else None,
-                    middle_name=(parsed.middle_name if parsed and parsed.middle_name else None),
+                    **self._routed_name_fields(parsed),
                     router_prediction=pred,
                     router_reason=row.get("router_reason", ""),
-                    pp=self._to_prediction(res, format_pattern=pp_fp.copy(deep=True)),
+                    pp=self._to_prediction(res, format_pattern=pp_fp),
                 )
             )
         return out
@@ -589,18 +602,10 @@ class Predictor:
         """
         if vys_pool_names:
             return self.route_pp_vys(pp_names, vys_pool_names)
+        # PPRoutedPrediction is a field-subset of RoutedPrediction; widen each to the unified
+        # shape by adding the PP-only sentinels (no venue pool → no vys / input_order_candidate).
         return [
-            RoutedPrediction(
-                success=r.success,
-                given_name=r.given_name,
-                surname=r.surname,
-                middle_name=r.middle_name,
-                router_prediction=r.router_prediction,
-                router_reason=r.router_reason,
-                input_order_candidate=None,
-                pp=r.pp,
-                vys=None,
-            )
+            RoutedPrediction(**r.dict(), input_order_candidate=None, vys=None)
             for r in self.route_pp(pp_names)
         ]
 

--- a/sinonym/timo/interface.py
+++ b/sinonym/timo/interface.py
@@ -161,6 +161,60 @@ class BatchSummary(TimoModel):
     confidences: list[float] = Field(description="per-name confidence from individual_analyses, aligned with results")
 
 
+class RoutingDecisionValue(str, Enum):
+    """Serialized pp-vys-abstain router decision."""
+
+    PP = "pp"
+    VYS = "vys"
+    ABSTAIN = "abstain"
+    NOT_PERSON = "not_person"
+
+
+class InputOrderCandidateValue(str, Enum):
+    """Which batch (pp/vys) preserves the input/given-first order; unknown if neither uniquely does."""
+
+    PP = "pp"
+    VYS = "vys"
+    UNKNOWN = "unknown"
+
+
+class RoutedPrediction(TimoModel):
+    """PP-vs-VYS routed result for one author, plus everything needed to inspect/re-run the router.
+
+    `given_name`/`surname`/`middle_name`/`success` are the FINAL routed answer: the PP parse
+    when `router_prediction=='pp'`, the VYS parse when `'vys'`, the input-order side
+    (`input_order_candidate`) when `'abstain'`, and empty when `'not_person'`.
+    """
+
+    success: bool = Field(description="Whether the routed answer is a recognized Chinese person")
+    given_name: str | None = Field(default=None)
+    surname: str | None = Field(default=None)
+    middle_name: str | None = Field(default=None)
+    router_prediction: RoutingDecisionValue = Field(description="pp / vys / abstain / not_person")
+    router_reason: str = Field(description="rule that produced router_prediction")
+    input_order_candidate: InputOrderCandidateValue | None = Field(
+        default=None, description="pp/vys/unknown; abstain resolves to this side. None in PP-only mode."
+    )
+    pp: Prediction = Field(description="the paper-batch (PP) parse for this author")
+    vys: Prediction | None = Field(default=None, description="the VYS parse; None in PP-only mode (no venue pool)")
+
+
+class PPRoutedPrediction(TimoModel):
+    """PP-only (pp-abstain) routed result for one author.
+
+    `given_name`/`surname`/`middle_name`/`success` are the FINAL routed answer: the PP parse when
+    `router_prediction=='pp'`, the input-order parse when `'abstain'`, empty when `'not_person'`.
+    """
+
+    success: bool = Field(description="Whether the routed answer is a recognized Chinese person")
+    given_name: str | None = Field(default=None)
+    surname: str | None = Field(default=None)
+    middle_name: str | None = Field(default=None)
+    router_prediction: RoutingDecisionValue = Field(description="pp / abstain (pp-abstain router never emits vys or not_person)")
+    router_reason: str = Field(description="rule that produced router_prediction")
+    pp: Prediction = Field(description="the paper-batch (PP) parse for this author")
+
+
 class PredictorConfig(BaseSettings):
     pass
 
@@ -345,3 +399,184 @@ class Predictor:
         """analyze_name_batch trimmed to names, results, format_pattern, per-name confidence."""
         batch_result = self._detector.analyze_name_batch(names, **self._batch_kwargs(format_threshold, minimum_batch_size))
         return self._to_batch_summary(batch_result)
+
+    # ---- pp-vys routing ---------------------------------------------------
+
+    def route_pp_vys(
+        self,
+        pp_names: list[str],
+        vys_pool_names: list[str],
+    ) -> list[RoutedPrediction]:
+        """Run the pp-vys-abstain router for one paper's authors.
+
+        - `pp_names`: the paper's author names (the PP batch); output is aligned to this order.
+        - `vys_pool_names`: the venue-source-year author pool (the VYS batch), with **the paper's
+          own authors as the FIRST `len(pp_names)` entries** (same strings, same order as
+          `pp_names`), followed by the other venue authors. Validated:
+          `vys_pool_names[:len(pp_names)] == pp_names`, else ValueError.
+
+        The full pool sets the VYS batch order-vote (parsing is order-independent, so only the
+        set of names matters); the paper's authors are the leading slice, so their VYS parses are
+        `vys_pool_names[:len(pp_names)]`. Returns one RoutedPrediction per pp author: the FINAL
+        routed parse plus the PP and VYS candidate parses and the router
+        decision/reason/input_order_candidate. Routing emits the PP parse for `pp`, the VYS parse
+        for `vys`, the `input_order_candidate` side for `abstain`, nothing for `not_person`.
+
+        Example — build `vys_pool_names` as the paper's authors FIRST, then the *other* venue
+        authors (do NOT re-include the paper's authors again; that would double-count them in the
+        vote):
+
+            pp_names = ["Yue Lin", "Wei Wang"]                 # this paper's 2 authors
+            other_venue_authors = ["Jun Zhao", "Hui Li", ...]  # rest of the venue-source-year pool
+            vys_pool_names = pp_names + other_venue_authors     # paper authors first
+            predictor.route_pp_vys(pp_names, vys_pool_names)
+
+        Returns 2 RoutedPredictions (one per pp author), aligned to `pp_names`.
+        """
+        from sinonym.coretypes import BatchParseResult
+        from sinonym.pipeline.name_order_routing import route_pp_vys_abstain_batches
+
+        n = len(pp_names)
+        if len(vys_pool_names) < n:
+            message = (
+                f"vys_pool_names (len {len(vys_pool_names)}) must contain at least the paper's "
+                f"{n} authors — the paper is a subset of the venue pool"
+            )
+            raise ValueError(message)
+        if list(vys_pool_names[:n]) != list(pp_names):
+            message = "vys_pool_names must start with the paper's authors: vys_pool_names[:len(pp_names)] == pp_names"
+            raise ValueError(message)
+        if not pp_names:
+            return []
+
+        pp_batch = self._detector.analyze_name_batch(pp_names)
+        pool = self._detector.analyze_name_batch(vys_pool_names)
+        # The paper's authors are the leading slice of the pool (pool.names[:n] == pp_names, checked
+        # above), so take the VYS batch context straight from the pool's own leading slice.
+        vys_batch = BatchParseResult(
+            names=list(pool.names[:n]),
+            results=list(pool.results[:n]),
+            format_pattern=pool.format_pattern,
+            individual_analyses=list(pool.individual_analyses[:n]),
+            improvements=[i for i in pool.improvements if i < n],
+            name_order_evidence=list(pool.name_order_evidence[:n]),
+        )
+        rows = route_pp_vys_abstain_batches(pp_batch, vys_batch)
+
+        pp_fp = self._to_format_pattern(pp_batch.format_pattern)
+        vys_fp = self._to_format_pattern(vys_batch.format_pattern)
+        out: list[RoutedPrediction] = []
+        for i, row in enumerate(rows):
+            pred = row["router_prediction"]
+            ioc = row.get("input_order_candidate", "unknown")
+            pp_res = pp_batch.results[i]
+            vys_res = vys_batch.results[i]
+            if pred == "pp":
+                chosen = pp_res
+            elif pred == "vys":
+                chosen = vys_res
+            elif pred == "abstain":
+                # abstain always carries input_order_candidate "pp" or "vys" (never "unknown");
+                # emit that (given-first) side, and fail loudly if the invariant ever breaks.
+                chosen = {"pp": pp_res, "vys": vys_res}.get(ioc)
+                if chosen is None:
+                    message = f"abstain with unexpected input_order_candidate={ioc!r} (expected 'pp'/'vys')"
+                    raise ValueError(message)
+            elif pred == "not_person":
+                chosen = None
+            else:
+                message = f"pp-vys router returned unexpected router_prediction={pred!r}"
+                raise ValueError(message)
+            parsed = chosen.parsed if (chosen is not None and chosen.success) else None
+            out.append(
+                RoutedPrediction(
+                    success=bool(chosen is not None and chosen.success),
+                    given_name=parsed.given_name if parsed else None,
+                    surname=parsed.surname if parsed else None,
+                    middle_name=(parsed.middle_name if parsed and parsed.middle_name else None),
+                    router_prediction=pred,
+                    router_reason=row.get("router_reason", ""),
+                    input_order_candidate=ioc,
+                    pp=self._to_prediction(pp_res, format_pattern=pp_fp.copy(deep=True)),
+                    vys=self._to_prediction(vys_res, format_pattern=vys_fp.copy(deep=True)),
+                )
+            )
+        return out
+
+    def route_pp(self, names: list[str]) -> list[PPRoutedPrediction]:
+        """PP-only (pp-abstain) router — for when there is no VYS venue pool.
+
+        Runs a single PP batch and applies the self-contained pp-abstain router, which decides
+        per author between `pp` (trust the PP-batch reorder), `abstain` (keep the input-order
+        parse), and `not_person`. Returns one PPRoutedPrediction per name (aligned to `names`):
+        the final routed parse + decision/reason + the PP candidate parse.
+        """
+        from sinonym.pipeline.name_order_routing import (
+            build_pp_abstain_rows,
+            route_pp_abstain_rows,
+        )
+
+        if not names:
+            return []
+
+        pp_batch = self._detector.analyze_name_batch(names)
+        rows = route_pp_abstain_rows(build_pp_abstain_rows(pp_batch, self._detector))
+        pp_fp = self._to_format_pattern(pp_batch.format_pattern)
+
+        out: list[PPRoutedPrediction] = []
+        for i, row in enumerate(rows):
+            pred = row["router_prediction"]
+            res = pp_batch.results[i]
+            if pred == "pp":
+                parsed = res.parsed if res.success else None
+            elif pred == "abstain":
+                parsed = res.parsed_original_order if res.success else None
+            elif pred == "not_person":  # valid Route value; emit nothing (pp-abstain router doesn't produce it today)
+                parsed = None
+            else:
+                message = f"pp-abstain router returned unexpected router_prediction={pred!r}"
+                raise ValueError(message)
+            out.append(
+                PPRoutedPrediction(
+                    success=bool(parsed is not None),
+                    given_name=parsed.given_name if parsed else None,
+                    surname=parsed.surname if parsed else None,
+                    middle_name=(parsed.middle_name if parsed and parsed.middle_name else None),
+                    router_prediction=pred,
+                    router_reason=row.get("router_reason", ""),
+                    pp=self._to_prediction(res, format_pattern=pp_fp.copy(deep=True)),
+                )
+            )
+        return out
+
+    def route(
+        self,
+        pp_names: list[str],
+        vys_pool_names: list[str] | None = None,
+    ) -> list[RoutedPrediction]:
+        """Unified router: use PP+VYS routing when a venue pool is given, else PP-only fallback.
+
+        - If `vys_pool_names` is falsy (None or empty), routes PP-only via the pp-abstain router
+          (`route_pp`); returned `RoutedPrediction`s have `vys=None` and `input_order_candidate=None`.
+        - Otherwise routes PP-vs-VYS via `route_pp_vys` (paper authors must be the leading slice of
+          `vys_pool_names`; see that method).
+
+        Always returns `list[RoutedPrediction]` (one per pp author, aligned to `pp_names`), so callers
+        get a single response shape whether or not venue context is available.
+        """
+        if vys_pool_names:
+            return self.route_pp_vys(pp_names, vys_pool_names)
+        return [
+            RoutedPrediction(
+                success=r.success,
+                given_name=r.given_name,
+                surname=r.surname,
+                middle_name=r.middle_name,
+                router_prediction=r.router_prediction,
+                router_reason=r.router_reason,
+                input_order_candidate=None,
+                pp=r.pp,
+                vys=None,
+            )
+            for r in self.route_pp(pp_names)
+        ]

--- a/sinonym/timo/interface.py
+++ b/sinonym/timo/interface.py
@@ -577,12 +577,13 @@ class Predictor:
             if pred == "pp":
                 parsed = res.parsed if res.success else None
             elif pred == "abstain":
-                # Single-batch regime: the "input-order parse" IS the PP-batch parse — there is no
-                # second batch / input_order_candidate to pick (unlike route_pp_vys). res.parsed and
-                # res.parsed_original_order carry the same surname/given (they differ only in the
-                # display `order`, which this endpoint drops), so abstain emits the same name as pp;
-                # the decision differs only as a confidence label.
-                parsed = res.parsed if res.success else None
+                # abstain = "emit the preprocessed input-order parse" (keep the name as typed, don't
+                # apply the batch reorder). res.parsed carries the BATCH reading, which differs from
+                # the input order whenever the batch reordered this name — so re-parse the name in
+                # isolation to get its normalized standalone (input-order) parse. Falls back to the
+                # batch parse only if the name won't parse standalone.
+                standalone = self._detector.normalize_name(names[i])
+                parsed = standalone.parsed if standalone.success else (res.parsed if res.success else None)
             elif pred == "not_person":  # valid Route value; emit nothing (pp-abstain router doesn't produce it today)
                 parsed = None
             else:

--- a/sinonym/timo/interface.py
+++ b/sinonym/timo/interface.py
@@ -219,8 +219,8 @@ class RoutingInstance(TimoModel):
     """One paper's authors for the routing-served variant (`RoutingPredictor.predict_batch`).
 
     Self-contained per instance (the timo runner feeds one Instance at a time), so each carries
-    its own venue pool. `predict_batch([paper])` returns `len(pp_names)` RoutedPredictions in
-    `pp_names` order.
+    its own venue pool. One `RoutingInstance` maps to exactly one `RoutedPaperPrediction`, whose
+    `authors` list holds `len(pp_names)` routed authors in `pp_names` order.
     """
 
     pp_names: list[str] = Field(description="the paper's author names (PP batch); output aligns to this order")
@@ -231,6 +231,20 @@ class RoutingInstance(TimoModel):
             "entries (same strings/order as pp_names), then the other venue authors. None/empty => "
             "PP-only routing fallback."
         ),
+    )
+
+
+class RoutedPaperPrediction(TimoModel):
+    """One paper's routed result — the timo `Prediction` for the `sinonym_routing_v1` variant.
+
+    Keeps the timo contract 1:1 (one Prediction per `RoutingInstance`) while carrying the paper's
+    per-author routed results in `authors` (aligned to `pp_names`). A paper with no authors yields
+    `authors=[]`, so instances never silently vanish from the output stream.
+    """
+
+    authors: list[RoutedPrediction] = Field(
+        default_factory=list,
+        description="per-author routed results, aligned to the instance's pp_names",
     )
 
 
@@ -611,15 +625,15 @@ class Predictor:
 
 
 class RoutingPredictor(Predictor):
-    """timo-served routing variant: Instance = one paper, Prediction = per-author RoutedPrediction.
+    """timo-served routing variant: one RoutingInstance (paper) -> one RoutedPaperPrediction.
 
-    Wraps `Predictor.route`. Each RoutingInstance yields `len(pp_names)` RoutedPredictions (in
-    pp_names order); the timo runner writes each on its own line, so paper boundaries are the
-    order in which authors are emitted (one instance's authors are contiguous).
+    Wraps `Predictor.route`. Stays 1:1 with the timo instance/prediction contract — the paper's
+    per-author routed results are nested in `RoutedPaperPrediction.authors` (aligned to pp_names),
+    so paper boundaries are explicit and empty papers still emit one prediction.
     """
 
-    def predict_batch(self, instances: list[RoutingInstance]) -> list[RoutedPrediction]:  # type: ignore[override]
-        out: list[RoutedPrediction] = []
-        for inst in instances:
-            out.extend(self.route(inst.pp_names, inst.vys_pool_names))
-        return out
+    def predict_batch(self, instances: list[RoutingInstance]) -> list[RoutedPaperPrediction]:  # type: ignore[override]
+        return [
+            RoutedPaperPrediction(authors=self.route(inst.pp_names, inst.vys_pool_names))
+            for inst in instances
+        ]

--- a/tests/test_timo_interface.py
+++ b/tests/test_timo_interface.py
@@ -9,6 +9,9 @@ from sinonym.timo.interface import (
     Prediction,
     Predictor,
     PredictorConfig,
+    RoutedPaperPrediction,
+    RoutingInstance,
+    RoutingPredictor,
     ScriptRepresentationValue,
 )
 
@@ -393,3 +396,24 @@ def test_route_unified_falls_back_to_pp_when_no_pool(predictor: Predictor):
     ]
     assert all(r.vys is not None for r in out)
     assert isinstance(out[0].dict(), dict)
+
+
+# --- RoutingPredictor: timo 1:1 instance->prediction contract ----------------
+
+def test_routing_predictor_one_prediction_per_instance():
+    rp = RoutingPredictor(config=PredictorConfig(), artifacts_dir=".")
+    instances = [
+        RoutingInstance(pp_names=["Yue Lin", "Wei Wang"], vys_pool_names=["Yue Lin", "Wei Wang", "Jun Zhao"]),
+        RoutingInstance(pp_names=["Zhang San"]),  # PP-only
+        RoutingInstance(pp_names=[]),              # empty paper must still emit one prediction
+    ]
+    results = rp.predict_batch(instances)
+
+    # the guard timo's InferenceServerContainer asserts: len(predictions) == len(instances)
+    assert len(results) == len(instances)
+    assert all(isinstance(p, RoutedPaperPrediction) for p in results)
+    assert [len(p.authors) for p in results] == [2, 1, 0]
+
+    # timo reconstructs each prediction via prediction_class(**raw_pred); round-trip must hold
+    rebuilt = [RoutedPaperPrediction(**p.dict()) for p in results]
+    assert rebuilt == results

--- a/tests/test_timo_interface.py
+++ b/tests/test_timo_interface.py
@@ -326,24 +326,29 @@ def test_route_pp_exact_values(predictor: Predictor):
 # The exact-value fixtures above only route to pp/vys. These lock the abstain
 # branches, which the routers do exercise on real batches.
 
-def test_route_pp_abstain_emits_batch_reading(predictor: Predictor):
-    """PP-only abstain: single-batch regime has no input_order_candidate to pick, so the
-    routed answer IS the PP-batch parse (abstain emits the same name as pp would)."""
+def test_route_pp_abstain_emits_input_order_parse(predictor: Predictor):
+    """PP-only abstain = "keep the input-order parse": emit the name's normalized standalone
+    reading, NOT the (possibly reordered) PP-batch reading."""
     pp = ["Lin Yue", "Wang Wei", "Yang Chuang", "Zhao Jun", "Li Hui"]
     out = predictor.route_pp(pp)
 
     assert [r.router_prediction.value for r in out] == ["abstain"] * len(pp)
-    # every abstain row emits its PP candidate parse (not something else)
-    for r in out:
-        assert r.success
-        assert (r.surname, r.given_name) == (r.pp.surname, r.pp.given_name)
-    assert [(r.given_name, r.surname) for r in out] == [
-        ("Lin", "Yue"),
-        ("Wang", "Wei"),
-        ("Yang", "Chuang"),
-        ("Zhao", "Jun"),
-        ("Li", "Hui"),
-    ]
+    assert all(r.success for r in out)
+    # each abstain row is the name's input-order (standalone) reading; assert every component
+    expected = {
+        "Lin Yue": ("Lin", None, "Yue"),
+        "Wang Wei": ("Wei", None, "Wang"),      # input order kept (batch would flip to Wang/Wei)
+        "Yang Chuang": ("Yang", None, "Chuang"),
+        "Zhao Jun": ("Jun", None, "Zhao"),      # input order kept (batch would flip to Zhao/Jun)
+        "Li Hui": ("Li", None, "Hui"),
+    }
+    for name, r in zip(pp, out):
+        assert (r.given_name, r.middle_name, r.surname) == expected[name]
+    # the batch reordered "Wang Wei"/"Zhao Jun"; abstain reverts to input order, so the routed
+    # answer differs from the PP candidate there (proving abstain is not a no-op)
+    for name in ("Wang Wei", "Zhao Jun"):
+        r = next(r for n, r in zip(pp, out) if n == name)
+        assert (r.given_name, r.surname) != (r.pp.given_name, r.pp.surname)
 
 
 def test_route_pp_vys_abstain_picks_input_order_candidate(predictor: Predictor):
@@ -357,9 +362,12 @@ def test_route_pp_vys_abstain_picks_input_order_candidate(predictor: Predictor):
     for r in out:
         assert r.input_order_candidate.value == "pp"
         # the pick is meaningful: pp and vys candidates genuinely disagree here
-        assert (r.pp.surname, r.pp.given_name) != (r.vys.surname, r.vys.given_name)
-        assert (r.surname, r.given_name) == (r.pp.surname, r.pp.given_name)
-    assert [(r.given_name, r.surname) for r in out] == [("Na", "Li"), ("Jie", "Chen")]
+        assert (r.pp.given_name, r.pp.middle_name, r.pp.surname) != (r.vys.given_name, r.vys.middle_name, r.vys.surname)
+        # routed answer equals the chosen (pp) candidate, component by component
+        assert (r.given_name, r.middle_name, r.surname) == (r.pp.given_name, r.pp.middle_name, r.pp.surname)
+    na, jie = out
+    assert (na.given_name, na.middle_name, na.surname) == ("Na", None, "Li")
+    assert (jie.given_name, jie.middle_name, jie.surname) == ("Jie", None, "Chen")
 
     # ioc=vys: the abstaining author resolves to the VYS reading
     pp2 = ["Lei Sun", "Sima Qian"]
@@ -368,9 +376,10 @@ def test_route_pp_vys_abstain_picks_input_order_candidate(predictor: Predictor):
     sima = out2[1]
     assert sima.router_prediction.value == "abstain"
     assert sima.input_order_candidate.value == "vys"
-    assert (sima.pp.surname, sima.pp.given_name) != (sima.vys.surname, sima.vys.given_name)
-    assert (sima.surname, sima.given_name) == (sima.vys.surname, sima.vys.given_name)
-    assert (sima.given_name, sima.surname) == ("Sima", "Qian")
+    assert (sima.pp.given_name, sima.pp.middle_name, sima.pp.surname) != (sima.vys.given_name, sima.vys.middle_name, sima.vys.surname)
+    # routed answer equals the chosen (vys) candidate, component by component
+    assert (sima.given_name, sima.middle_name, sima.surname) == (sima.vys.given_name, sima.vys.middle_name, sima.vys.surname)
+    assert (sima.given_name, sima.middle_name, sima.surname) == ("Sima", None, "Qian")
 
 
 

--- a/tests/test_timo_interface.py
+++ b/tests/test_timo_interface.py
@@ -319,6 +319,55 @@ def test_route_pp_exact_values(predictor: Predictor):
     assert predictor.route_pp([]) == []
 
 
+# --- abstain coverage -------------------------------------------------------
+# The exact-value fixtures above only route to pp/vys. These lock the abstain
+# branches, which the routers do exercise on real batches.
+
+def test_route_pp_abstain_emits_batch_reading(predictor: Predictor):
+    """PP-only abstain: single-batch regime has no input_order_candidate to pick, so the
+    routed answer IS the PP-batch parse (abstain emits the same name as pp would)."""
+    pp = ["Lin Yue", "Wang Wei", "Yang Chuang", "Zhao Jun", "Li Hui"]
+    out = predictor.route_pp(pp)
+
+    assert [r.router_prediction.value for r in out] == ["abstain"] * len(pp)
+    # every abstain row emits its PP candidate parse (not something else)
+    for r in out:
+        assert r.success
+        assert (r.surname, r.given_name) == (r.pp.surname, r.pp.given_name)
+    assert [(r.given_name, r.surname) for r in out] == [
+        ("Lin", "Yue"),
+        ("Wang", "Wei"),
+        ("Yang", "Chuang"),
+        ("Zhao", "Jun"),
+        ("Li", "Hui"),
+    ]
+
+
+def test_route_pp_vys_abstain_picks_input_order_candidate(predictor: Predictor):
+    """PP-vs-VYS abstain resolves to the input_order_candidate side (pp/vys), per README
+    semantics + the routing fixture. Covers both ioc=pp and ioc=vys."""
+    # ioc=pp: both authors abstain and resolve to the PP reading (which differs from VYS)
+    pp = ["Na Li", "Jie Chen"]
+    pool = ["Na Li", "Jie Chen", "Yue Lin", "Zhang Wei", "Kai Yang", "Wang Fang", "Sima Qian"]
+    out = predictor.route_pp_vys(pp, pool)
+    assert [r.router_prediction.value for r in out] == ["abstain", "abstain"]
+    for r in out:
+        assert r.input_order_candidate.value == "pp"
+        # the pick is meaningful: pp and vys candidates genuinely disagree here
+        assert (r.pp.surname, r.pp.given_name) != (r.vys.surname, r.vys.given_name)
+        assert (r.surname, r.given_name) == (r.pp.surname, r.pp.given_name)
+    assert [(r.given_name, r.surname) for r in out] == [("Na", "Li"), ("Jie", "Chen")]
+
+    # ioc=vys: the abstaining author resolves to the VYS reading
+    pp2 = ["Lei Sun", "Sima Qian"]
+    pool2 = ["Lei Sun", "Sima Qian", "Jun Zhao", "Liu Yang", "Tao Sun", "Ming Li", "Hui Guo", "Kai Yang"]
+    out2 = predictor.route_pp_vys(pp2, pool2)
+    sima = out2[1]
+    assert sima.router_prediction.value == "abstain"
+    assert sima.input_order_candidate.value == "vys"
+    assert (sima.pp.surname, sima.pp.given_name) != (sima.vys.surname, sima.vys.given_name)
+    assert (sima.surname, sima.given_name) == (sima.vys.surname, sima.vys.given_name)
+    assert (sima.given_name, sima.surname) == ("Sima", "Qian")
 
 
 

--- a/tests/test_timo_interface.py
+++ b/tests/test_timo_interface.py
@@ -221,3 +221,126 @@ def test_analyze_name_batch_handles_detector_fallback_evidence(predictor: Predic
 
     assert len(result.name_order_evidence) == 1
     assert result.name_order_evidence[0].script_representation == ScriptRepresentationValue.UNKNOWN
+
+
+def test_route_pp_vys_requires_paper_authors_first(predictor: Predictor):
+    # paper authors not the leading slice of the pool -> raise
+    with pytest.raises(ValueError, match="must start with the paper"):
+        predictor.route_pp_vys(["Yue Lin", "Wei Wang"], ["Wei Wang", "Yue Lin", "Tao Sun"])
+
+
+def test_route_pp_vys_empty(predictor: Predictor):
+    assert predictor.route_pp_vys([], []) == []
+
+
+def test_route_pp_vys_matches_manual_pp_then_vys_then_router(predictor: Predictor):
+    """Documents the underlying flow: run PP batch, run VYS batch, feed BOTH to the router.
+
+    `route_pp_vys` is a thin wrapper over exactly these steps; this test rebuilds them by hand
+    and asserts the routed answers match.
+    """
+    from sinonym.coretypes import BatchParseResult
+    from sinonym.detector import ChineseNameDetector
+    from sinonym.pipeline.name_order_routing import (
+        build_pp_vys_abstain_rows,
+        route_pp_vys_abstain_rows,
+    )
+
+    pp_names = ["Yue Lin", "Wei Wang", "Chuang Yang"]
+    # paper authors first, then the other venue authors
+    vys_pool = ["Yue Lin", "Wei Wang", "Chuang Yang", "Jun Zhao", "Hui Li", "Tao Sun", "Min Guo"]
+    n = len(pp_names)
+
+    detector = ChineseNameDetector()
+    # 1) PP batch: the paper's authors, parsed jointly
+    pp_batch = detector.analyze_name_batch(pp_names)
+    # 2) VYS batch: the venue-source-year pool, parsed jointly, then aligned to the paper's authors
+    pool = detector.analyze_name_batch(vys_pool)
+    vys_batch = BatchParseResult(
+        names=list(pp_names),
+        results=list(pool.results[:n]),
+        format_pattern=pool.format_pattern,
+        individual_analyses=[],
+        improvements=set(),
+        name_order_evidence=list(pool.name_order_evidence[:n]),
+    )
+    # 3) feed both batch results to the router
+    routed_rows = route_pp_vys_abstain_rows(build_pp_vys_abstain_rows(pp_batch, vys_batch))
+
+    def manual_surname(i):
+        pred = routed_rows[i]["router_prediction"]
+        ioc = routed_rows[i].get("input_order_candidate", "unknown")
+        if pred == "pp":
+            res = pp_batch.results[i]
+        elif pred == "vys":
+            res = vys_batch.results[i]
+        elif pred == "abstain":
+            res = vys_batch.results[i] if ioc == "vys" else pp_batch.results[i]
+        else:
+            return None
+        return res.parsed.surname if (res.success and res.parsed) else None
+
+    # the wrapper endpoint reproduces the manual PP->VYS->router result
+    endpoint = predictor.route_pp_vys(pp_names, vys_pool)
+    assert [manual_surname(i) for i in range(len(pp_names))] == [r.surname for r in endpoint]
+    assert [routed_rows[i]["router_prediction"] for i in range(len(pp_names))] == [
+        r.router_prediction for r in endpoint
+    ]
+
+
+# Fixed-scenario regression: exact routed values for v0.2.9 (batch-composition dependent).
+ROUTE_SCENARIO_PP = ["Yue Lin", "Wei Wang", "Chuang Yang"]
+ROUTE_SCENARIO_POOL = ["Yue Lin", "Wei Wang", "Chuang Yang", "Jun Zhao", "Hui Li", "Tao Sun", "Min Guo"]
+
+
+def test_route_pp_vys_exact_values(predictor: Predictor):
+    out = predictor.route_pp_vys(ROUTE_SCENARIO_PP, ROUTE_SCENARIO_POOL)
+    got = [(r.router_prediction.value, r.given_name, r.surname) for r in out]
+    assert got == [
+        ("pp", "Lin", "Yue"),
+        ("vys", "Wei", "Wang"),
+        ("vys", "Chuang", "Yang"),
+    ]
+    # candidate parses carried through exactly
+    assert (out[1].pp.given_name, out[1].pp.surname) == ("Wang", "Wei")   # PP (paper-batch) reading
+    assert (out[1].vys.given_name, out[1].vys.surname) == ("Wei", "Wang")  # VYS (venue-pool) reading
+
+
+def test_route_pp_exact_values(predictor: Predictor):
+    out = predictor.route_pp(ROUTE_SCENARIO_PP)
+    got = [(r.router_prediction.value, r.given_name, r.surname) for r in out]
+    # NB: differs from route_pp_vys on "Wei Wang" — PP-only keeps the PP-batch reading
+    # (given=Wang/surname=Wei) whereas route_pp_vys routed it to VYS (given=Wei/surname=Wang).
+    assert got == [
+        ("pp", "Lin", "Yue"),
+        ("pp", "Wang", "Wei"),
+        ("pp", "Yang", "Chuang"),
+    ]
+    assert predictor.route_pp([]) == []
+
+
+
+
+
+def test_route_unified_falls_back_to_pp_when_no_pool(predictor: Predictor):
+    from sinonym.timo.interface import RoutedPrediction
+
+    pp_names = ["Yue Lin", "Wei Wang", "Chuang Yang"]
+    pool = ["Yue Lin", "Wei Wang", "Chuang Yang", "Jun Zhao", "Hui Li", "Tao Sun", "Min Guo"]
+
+    # no pool (None or []) -> PP-only fallback: vys/input_order_candidate are None, matches route_pp
+    for empty in (None, []):
+        out = predictor.route(pp_names, empty)
+        assert all(isinstance(r, RoutedPrediction) for r in out)
+        assert all(r.vys is None and r.input_order_candidate is None for r in out)
+        assert all(r.router_prediction in {"pp", "abstain", "not_person"} for r in out)
+        pp_only = predictor.route_pp(pp_names)
+        assert [(r.given_name, r.surname) for r in out] == [(r.given_name, r.surname) for r in pp_only]
+
+    # with pool -> delegates to route_pp_vys (vys candidate present)
+    out = predictor.route(pp_names, pool)
+    assert [(r.given_name, r.surname) for r in out] == [
+        (r.given_name, r.surname) for r in predictor.route_pp_vys(pp_names, pool)
+    ]
+    assert all(r.vys is not None for r in out)
+    assert isinstance(out[0].dict(), dict)

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "sinonym"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },


### PR DESCRIPTION
## Summary

Exposes the sinonym **PP-vs-VYS name-order router** through the TIMO interface, plus a PP-only variant. Callers get the routed surname/given per author, the router's decision, and both candidate parses. Adds a timo-served variant (`sinonym_routing_v1`) that stays 1:1 with the timo instance/prediction contract. Version `0.2.8 → 0.2.9`.

## Library API (`Predictor`)

- **`route_pp_vys(pp_names, vys_pool_names)` → `list[RoutedPrediction]`** — runs the PP batch and the VYS (venue·source·year pool) batch, aligns the paper's authors as the leading slice of the pool (`vys_pool_names[:len(pp_names)] == pp_names`, validated), applies the pp-vys-abstain router, and returns per author: the final routed parse (PP parse for `pp`, VYS parse for `vys`, the `input_order_candidate` side for `abstain`, empty for `not_person`), plus `router_prediction`, `router_reason`, `input_order_candidate`, and both `pp`/`vys` candidate `Prediction`s.
- **`route_pp(names)` → `list[PPRoutedPrediction]`** — PP-only (no venue pool). Applies the self-contained pp-abstain router (`pp` / `abstain` / `not_person`).
- **`route(pp_names, vys_pool_names=None)` → `list[RoutedPrediction]`** — unified entry: PP-vs-VYS when a pool is given, else PP-only fallback (`vys=None`, `input_order_candidate=None`). Single response shape either way.

## TIMO-served variant (`sinonym_routing_v1`)

`RoutingPredictor.predict_batch` maps **one `RoutingInstance` (paper) → one `RoutedPaperPrediction`**, whose `authors` list holds the per-author `RoutedPrediction`s (aligned to `pp_names`). This keeps timo's `len(predictions) == len(instances)` contract on every path (native, offline runner, HTTP, docker `InferenceServerContainer`), and an empty paper still emits one prediction (`authors=[]`) instead of silently vanishing.

`RoutingInstance` carries `pp_names` and an optional `vys_pool_names` (paper authors first, then the other venue authors; `None`/empty → PP-only routing).

## Abstain semantics

- **pp-vs-vys** — `abstain` resolves to the `input_order_candidate` side (the batch that read the name given-first), per `data/name_order_routing/README.md` + the routing fixture. Confirmed by the routing author; `abstain` + `input_order_candidate == "unknown"` cannot occur (documented router invariant), so this endpoint raises on it.
- **pp-only** — `abstain` means "emit the preprocessed input-order (as-typed) parse" (trailing token is the surname; don't apply the batch reorder). This PR implements it via a standalone re-parse, which the routing author has since corrected: the standalone detector re-decides order, so the proper mechanism is the deterministic `input_order_parsed()` materialization from `parsed_original_order` — that fix is stacked in the follow-up PR #18 (`reduce-baseline-to-19`, based on this branch) and supersedes this PR's abstain branch on merge.

## Also

- Cleanups: shared `_routed_name_fields` extraction, one batch-wide `format_pattern` per batch (no per-row deep copy), PP-only→unified widening via model spread.
- `analyze_name_batch` already emits all router-input evidence (`name_order_evidence`, `format_pattern`), so raw PP/VYS batches stay fully inspectable.

## Tests

- `RoutedPrediction`/`PPRoutedPrediction`/`RoutedPaperPrediction` coverage, including a test documenting the explicit **PP → VYS → router** flow, abstain-row coverage for both routers (pp-vys `ioc=pp`/`ioc=vys`, pp-only input-order), and the timo 1:1 round-trip (`RoutedPaperPrediction(**p.dict()) == p`).
- Routing + timo suites pass; `scripts/check_test_status.py` at the expected baseline (no new failures).
