### PR TITLE
Fix IndexError on name parts that are all combining marks (0.3.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sinonym"
-version = "0.3.0"
+version = "0.3.1"
 description = "Chinese Name Detection and Normalization Module"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinonym/utils/string_manipulation.py
+++ b/sinonym/utils/string_manipulation.py
@@ -590,6 +590,11 @@ class StringManipulationUtils:
         # Normalize Unicode and remove diacritical marks
         normalized = unicodedata.normalize("NFD", part)
         without_diacritics = "".join(c for c in normalized if unicodedata.category(c) != "Mn")
+        if not without_diacritics:
+            # Token was made up entirely of combining marks / variation selectors (all
+            # category Mn), so stripping them leaves nothing to capitalize. Return the
+            # empty result rather than indexing [0] into an empty string (IndexError).
+            return without_diacritics
         return without_diacritics[0].upper() + without_diacritics[1:].lower()
 
     @staticmethod

--- a/tests/test_bug_report_fixes.py
+++ b/tests/test_bug_report_fixes.py
@@ -539,3 +539,23 @@ def test_name_order_evidence_uses_cached_raw_tokens(detector):
 def test_name_order_routing_priors_are_imported_from_canonical_data():
     assert name_order_routing.NAME_PRIOR_COMMON_CHINESE_SURNAMES is chinese_names_data.NAME_ORDER_ROUTING_COMMON_CHINESE_SURNAMES
     assert name_order_routing.NAME_PRIOR_KOREAN_SURNAMES is chinese_names_data.NAME_ORDER_ROUTING_KOREAN_SURNAMES
+
+
+def test_capitalize_name_part_all_combining_marks_does_not_crash():
+    """Regression: a name part consisting solely of combining marks / variation selectors
+    (all Unicode category Mn) strips to '' after NFD + Mn removal. capitalize_name_part then
+    indexed [0] into the empty string and raised IndexError. It must now return '' instead."""
+    from sinonym.utils.string_manipulation import StringManipulationUtils
+
+    assert StringManipulationUtils.capitalize_name_part("́") == ""           # lone combining acute
+    assert StringManipulationUtils.capitalize_name_part("\U000E0100") == ""       # ideographic variation selector
+    # real names are unaffected (still stripped + capitalized)
+    assert StringManipulationUtils.capitalize_name_part("josé") == "Jose"
+    assert StringManipulationUtils.capitalize_name_part("ou-yang") == "Ou-Yang"
+
+
+def test_normalize_name_with_embedded_variation_selector_does_not_crash(detector):
+    """Integration regression: a corpus name with an embedded ideographic variation selector
+    (U+E0100, seen on paper_id 274957019) crashed normalize_name via the capitalize step."""
+    result = detector.normalize_name("彬人 樽\U000E0100井")  # 彬人 樽󠄀井
+    assert result is not None  # no exception raised; the classification value is out of scope here


### PR DESCRIPTION
What
----
capitalize_name_part strips Unicode Mn characters (combining marks, variation selectors) after NFD normalization. When a name part is composed **entirely** of Mn characters, stripping leaves an empty string, and the code then indexed [0] into it — raising IndexError and crashing normalize_name.

Fix: guard the empty case in _normalize_and_capitalize_single_part (utils/string_manipulation.py) and return the empty result instead of indexing. One-line behavioral guard; real names are unaffected.

Why it matters
----
Hit in a production backfill classifying every corpus author name. Example: paper_id 274957019, name `彬人 樽󠄀井`, which carries an ideographic variation selector U+E0100 (category Mn) between 樽 and 井. The whole batch/pool aborts on the raised exception, so a single pathological name blocks otherwise-clean data.

Repro (before this change)
----
```python
from sinonym import ChineseNameDetector
ChineseNameDetector().normalize_name("彬人 樽\U000E0100井")   # IndexError: string index out of range
```

Tests
----
Added two regression tests in tests/test_bug_report_fixes.py — a unit test on capitalize_name_part (lone combining mark and U+E0100 both return "", while josé→Jose and ou-yang→Ou-Yang are unchanged) and an integration test that normalize_name on the U+E0100 name no longer raises. Full file passes (42), ruff clean.

Note
----
Verified this crash still reproduces on the 0.4.0 branch (PR #19) at the same site (string_manipulation.py:593), so this guard is worth carrying forward there too. Separately, the embedded variation selector also defeats 0.4.0's Japanese-lexicon match (a distinct classification issue, not addressed here — that belongs in preprocessing).

Bumps 0.3.0 -> 0.3.1.