### PR TITLE
Render all-caps 2-letter credential initials as all-caps (0.4.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sinonym"
-version = "0.4.1"
+version = "0.4.2"
 description = "Chinese Name Detection and Normalization Module"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinonym/services/person_name_normalization.py
+++ b/sinonym/services/person_name_normalization.py
@@ -1405,13 +1405,10 @@ class PersonNameNormalizationService:
             return cleaned[0].upper() + "."
         if _MULTI_INITIAL_RE.fullmatch(cleaned) or self._is_uppercase_dotted_abbreviation(cleaned):
             return "".join(character.upper() if character.isalpha() else character for character in cleaned)
-        if (
-            role != "surname"
-            and cleaned.isalpha()
-            and cleaned.isupper()
-            and len(cleaned) == _TWO_COMPONENTS
-            and not self._is_ambiguous_credential(cleaned)
-        ):
+        if role != "surname" and cleaned.isalpha() and cleaned.isupper() and len(cleaned) == _TWO_COMPONENTS:
+            # A two-letter all-caps given token is initials (e.g. "MS", "MA", "MD") — keep it
+            # all-caps rather than title-casing to "Ms"/"Ma", which reads as an honorific. A
+            # genuine Title-case honorific never reaches here (it's dropped upstream).
             return cleaned
 
         parts = re.split(r"([-'])", cleaned)

--- a/tests/test_person_name_normalization.py
+++ b/tests/test_person_name_normalization.py
@@ -432,9 +432,9 @@ def test_uppercase_leading_credential_is_dropped(
     ("raw_name", "expected", "expected_given", "expected_surname"),
     [
         ("JOHN MA", "John Ma", "John", "Ma"),
-        ("MA SMITH", "Ma Smith", "Ma", "Smith"),
-        ("Smith, Ma", "Ma Smith", "Ma", "Smith"),
-        ("SMITH, MA", "Ma Smith", "Ma", "Smith"),
+        ("MA SMITH", "MA Smith", "MA", "Smith"),  # all-caps initials kept all-caps
+        ("Smith, Ma", "Ma Smith", "Ma", "Smith"),  # Title-case input stays Title-case
+        ("SMITH, MA", "MA Smith", "MA", "Smith"),
     ],
 )
 def test_ambiguous_uppercase_credential_token_is_preserved_when_required_as_name(
@@ -1537,8 +1537,8 @@ def test_name_without_entity_is_unaffected_by_decode(
         # Leading given/initials that collide with a credential/title acronym were
         # dropped, collapsing the name (surname left EMPTY: "MS Islam" -> given "Islam").
         # Now the leading token is kept and the surname is restored.
-        ("MS Islam", ("Islam",), "Ms"),          # all-caps initials, not the "Ms" honorific
-        ("MS Ali", ("Ali",), "Ms"),
+        ("MS Islam", ("Islam",), "MS"),          # all-caps initials, kept all-caps (not the "Ms" honorific)
+        ("MS Ali", ("Ali",), "MS"),
         ("M-S. Barisits", ("Barisits",), "M-S."),
         ("M-S Barisits", ("Barisits",), "M-S"),
         ("Edd Gent", ("Gent",), "Edd"),           # "Edd" given, not the "EdD" degree
@@ -1617,10 +1617,10 @@ def test_credential_collision_hard_and_ambiguous_cases_characterization(
     None is a regression vs the pre-fix baseline (which dropped the leading token
     entirely and produced an empty surname or lost the María given).
     """
-    # (1) "MS" is kept (surname restored) but re-cased to Title-case "Ms" downstream,
-    #     so the given reads like the honorific. Cosmetic; the surname is now correct.
+    # (1) "MS" is kept as all-caps initials (surname restored); it no longer re-cases to
+    #     the "Ms" honorific.
     r = normalizer.normalize_text("MS Islam")
-    assert r.canonical_name.text == "Ms Islam"
+    assert r.canonical_name.text == "MS Islam"
     assert r.canonical_name.normalized.surname_tokens == ("Islam",)
 
     # (2) "Ma. de los Ángeles Martínez Ortega": a Mexican compound. The strong particle


### PR DESCRIPTION
@sergeyf — one small, final nit on top of the credential fix. **Rendering only** (no parse change), so it's low-risk; opening it separately so it's easy to review.

## What & why

In 0.4.1 the credential fix recovered the surname for **all-caps** credential-collision initials (`MS`/`MA`/`MD`/…), but the given got **re-cased to Title-case** (`MS Rahman` → given `Ms`), so a kept *initials* token looked identical to the dropped `Ms.` *honorific*. This keeps a **2-letter all-caps** given/middle token **all-caps**, so initials stay initials and no longer collide visually with the honorific.

**Casing is (and stays) the discriminator — nothing about the drop logic changes:**
- **all-caps** `MS Rahman` = initials → **kept** (0.4.1 rendered `Ms`; 0.4.2 renders `MS`).
- **Title-case** `Ms Rahman` = honorific → **dropped** (unchanged in both).

So `MS Rahman` (all-caps) and `Ms Rahman` (Title-case) are *different inputs* — 0.4.1 happened to render the kept one as `Ms`, which is the confusing collision this PR removes.

One-line change in `_canonicalize_token` (drop the `not is_ambiguous_credential` exclusion from the 2-letter all-caps branch) + test updates + version bump to 0.4.2.

## 0.4.0 → 0.4.1 → 0.4.2 by use case (`given / middle / surname`)

**1. Leading initials + surname (the common case).** 0.4.0 dropped the leading token and left an empty surname; 0.4.1 recovered the surname but title-cased the initials; 0.4.2 keeps them all-caps.

| input | 0.4.0 | 0.4.1 | 0.4.2 |
|---|---|---|---|
| `MS Rahman` | `Rahman / — / —` (empty surname) | `Ms / — / Rahman` | `MS / — / Rahman` |
| `MA Hassan` | `Ma / — / Hassan` | `Ma / — / Hassan` | `MA / — / Hassan` |
| `MD Ohman` | `Ohman / — / —` | `Md / — / Ohman` | `MD / — / Ohman` |
| `JD Baum` | `Jd / — / Baum` | `Jd / — / Baum` | `JD / — / Baum` |

**2. Middle-position / non-leading initials.** Same rendering fix, mid-name.

| input | 0.4.1 | 0.4.2 |
|---|---|---|
| `Miranda MA Whitten` | `Miranda / Ma / Whitten` | `Miranda / MA / Whitten` |
| `Sita MA Bierma-Zeinstra` | `Sita / Ma / Bierma-Zeinstra` | `Sita / MA / Bierma-Zeinstra` |
| `John MS Bartlett` | `John / Ms / Bartlett` | `John / MS / Bartlett` |
| `Gérard MD Ducable` | `Gérard / Md / Ducable` | `Gérard / MD / Ducable` |

**3. Genuine honorifics — still dropped (unchanged).** Casing is the signal: all-caps = initials (kept), Title-case = honorific (dropped).

| input | 0.4.1 | 0.4.2 |
|---|---|---|
| `Ms Rahman` | `— / — / Rahman` (Ms dropped) | `— / — / Rahman` (unchanged) |
| `Ms. Subbulakshmi` | `— / — / Subbulakshmi` | `— / — / Subbulakshmi` |
| `Dr Watson` | `— / — / Watson` | `— / — / Watson` |

**4. Degrees — still dropped (unchanged).** Trailing/mixed-case degree forms are unaffected.

| input | 0.4.1 | 0.4.2 |
|---|---|---|
| `Jane Doe EdD` | `Jane / — / Doe` (EdD dropped) | unchanged |
| `Robert Jones MD` | `Robert / — / Jones` (MD dropped) | unchanged |

## Verification

Ran **both** 0.4.1 and 0.4.2 on the **complete affected population** — every corpus name containing an all-caps 2-letter credential token in *any* position (leading, middle, comma-form): **247,855 names**.

- **31,628 changed** — **100% rendering-only** (code-checked: identical tokens in identical slots, differing only by letter case), **0 regressions** (no surname / order / accept-reject change vs 0.4.1).
- Split: **22,718 leading** (given) + **8,910 non-leading** (middle/comma).
- Real people are the bulk (`MS Rahman` = 89 papers with all-initials co-authors; `Miranda MA Whitten`, `John MS Bartlett`, …). The set also contains messy multi-credential affiliation strings (`MBBS MS FRACS Winy Widjaja`) where the rendering is cosmetically applied but the string is junk regardless — a separate reject gap, unchanged here.

Tests: added/updated cases for the all-caps rendering; full suite unchanged otherwise (only the pre-existing Chinese-routing failures remain, 0 new). `ruff` clean.
