### PR TITLE
Drop Title-case credential prefixes; keep hyphenated initials (0.4.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sinonym"
-version = "0.4.2"
+version = "0.4.3"
 description = "Chinese Name Detection and Normalization Module"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinonym/services/person_name_normalization.py
+++ b/sinonym/services/person_name_normalization.py
@@ -82,6 +82,9 @@ _INITIAL_RE = re.compile(r"([^\W\d_])\.", re.UNICODE)
 _MULTI_INITIAL_RE = re.compile(r"(?:[^\W\d_]\.)+[^\W\d_]\.?", re.UNICODE)
 _ABBREVIATED_TOKEN_RE = re.compile(r"(?:[^\W\d_]+[-'])*[^\W\d_]{1,3}\.", re.UNICODE)
 _COMPOUND_INITIAL_RE = re.compile(r"[^\W\d_]\.-[^\W\d_]\.", re.UNICODE)
+# Hyphenated single-letter groups are initials, never a degree ("M-A", "M.-A.", "J-D",
+# "M-S." — but not "MA"/"JD"): a hyphen distinguishes compound initials from a credential.
+_HYPHEN_INITIAL_RE = re.compile(r"[^\W\d_]\.?(?:-[^\W\d_]\.?)+", re.UNICODE)
 _LEADING_HYPHEN_INITIAL_RE = re.compile(r"^-([^\W\d_])\.$", re.UNICODE)
 _FUSED_INITIAL_SURNAME_RE = re.compile(r"^([^\W\d_])\.(.+)$", re.UNICODE)
 _LOWER_MARKER_INITIAL_RE = re.compile(r"^([a-z])([A-Z])\.$")
@@ -925,7 +928,13 @@ class PersonNameNormalizationService:
             leading_name_abbreviation = (
                 key in _LEADING_NAME_ABBREVIATION_KEYS and token.text.endswith(".") and len(remaining) >= _TWO_COMPONENTS
             ) or self._is_ma_given_abbreviation(remaining)
-            if self._is_credential(token.text) and not ambiguous_name_token and not leading_name_abbreviation:
+            hyphen_initials = bool(_HYPHEN_INITIAL_RE.fullmatch(token.text))
+            if (
+                self._is_credential(token.text)
+                and not ambiguous_name_token
+                and not leading_name_abbreviation
+                and not hyphen_initials
+            ):
                 dropped.append(_DroppedToken(token, DropReason.CREDENTIAL))
                 remaining.pop(0)
                 continue

--- a/sinonym/services/person_name_normalization.py
+++ b/sinonym/services/person_name_normalization.py
@@ -174,6 +174,11 @@ _CREDENTIAL_KEYS = frozenset(
     },
 )
 _AMBIGUOUS_CREDENTIAL_KEYS = frozenset({"ba", "bs", "do", "edd", "jd", "ma", "mba", "md", "meng", "mpa", "ms", "rn"})
+# Ambiguous credential keys that have ~no real given-name use (unlike "md"=Mohammad,
+# "ma"=María/Ma, "do"=Korean Do, "meng"=Meng, "ba"=Ba, "edd"=Edd, which are genuine names).
+# A Title-case one before a complete name is a credential prefix, not a given name, so it
+# should still drop ("Rn Rachael Zimlich" -> "Rachael Zimlich").
+_PURE_CREDENTIAL_TITLE_DROP_KEYS = frozenset({"bs", "jd", "mba", "mpa", "rn"})
 _MIXED_CASE_CREDENTIALS = {"meng": "MEng", "edd": "EdD"}
 _FAMILY_PARTICLES = frozenset(
     {
@@ -921,6 +926,19 @@ class PersonNameNormalizationService:
                 key in _LEADING_NAME_ABBREVIATION_KEYS and token.text.endswith(".") and len(remaining) >= _TWO_COMPONENTS
             ) or self._is_ma_given_abbreviation(remaining)
             if self._is_credential(token.text) and not ambiguous_name_token and not leading_name_abbreviation:
+                dropped.append(_DroppedToken(token, DropReason.CREDENTIAL))
+                remaining.pop(0)
+                continue
+            # A Title-case pure-credential token (Rn/Jd/Mba/Mpa/Bs) is a credential prefix,
+            # not a given name, when a complete name follows (>=2 following tokens, at least
+            # one non-initial surname): "Rn Rachael Zimlich" -> drop "Rn". A bare surname
+            # after it ("Rn Cahn") is left alone, since the token could be initials there.
+            if (
+                key in _PURE_CREDENTIAL_TITLE_DROP_KEYS
+                and not leading_name_abbreviation
+                and len(remaining) - 1 >= _TWO_COMPONENTS
+                and any(not self._is_initial(other.text) for other in remaining[1:])
+            ):
                 dropped.append(_DroppedToken(token, DropReason.CREDENTIAL))
                 remaining.pop(0)
                 continue

--- a/tests/test_person_name_normalization.py
+++ b/tests/test_person_name_normalization.py
@@ -471,6 +471,41 @@ def test_ambiguous_uppercase_credential_is_still_dropped_from_complete_name(
         ]
 
 
+def test_title_case_pure_credential_before_complete_name_is_dropped(
+    normalizer: PersonNameNormalizationService,
+) -> None:
+    # Title-case pure-credential tokens (Rn/Jd/Mba/Mpa/Bs) with no real given-name use are
+    # a credential prefix when a complete name follows, so they drop.
+    for raw, text in [("Rn Rachael Zimlich", "Rachael Zimlich"), ("Jd Dawn Collins", "Dawn Collins")]:
+        result = normalizer.normalize_text(raw)
+        assert result.outcome is PersonNameOutcome.PERSON
+        assert result.canonical_name is not None
+        assert result.canonical_name.text == text
+        assert [(token.text, token.reason) for token in result.dropped_tokens][:1] == [(raw.split()[0], DropReason.CREDENTIAL)]
+
+
+def test_title_case_pure_credential_before_bare_surname_is_kept(
+    normalizer: PersonNameNormalizationService,
+) -> None:
+    # Only a bare surname follows, so the token could be initials -> keep it, do not drop.
+    result = normalizer.normalize_text("Rn Cahn")
+    assert result.outcome is PersonNameOutcome.PERSON
+    assert result.canonical_name is not None
+    assert result.canonical_name.normalized.given_name == "Rn"
+    assert result.canonical_name.normalized.surname == "Cahn"
+
+
+def test_name_collision_credential_key_is_not_dropped_from_title_case(
+    normalizer: PersonNameNormalizationService,
+) -> None:
+    # "Md"=Mohammad is a real given name, not a credential, and must survive.
+    result = normalizer.normalize_text("Md Saiful Islam")
+    assert result.outcome is PersonNameOutcome.PERSON
+    assert result.canonical_name is not None
+    assert result.canonical_name.normalized.given_name == "Md"
+    assert result.canonical_name.normalized.surname == "Islam"
+
+
 def test_meng_surname_is_preserved_while_meng_degree_is_dropped(
     normalizer: PersonNameNormalizationService,
 ) -> None:

--- a/tests/test_person_name_normalization.py
+++ b/tests/test_person_name_normalization.py
@@ -506,6 +506,24 @@ def test_name_collision_credential_key_is_not_dropped_from_title_case(
     assert result.canonical_name.normalized.surname == "Islam"
 
 
+def test_hyphenated_initials_are_kept_not_dropped_as_credential(
+    normalizer: PersonNameNormalizationService,
+) -> None:
+    # "M-A"/"M.-A."/"J-D" are compound given-name initials (a hyphen -> initials, never a
+    # degree), so they are kept even though the bare "MA"/"JD" degree would drop.
+    for raw, given, surname in [("M-A Le Pogam", "M-A", "Le Pogam"), ("J-D Fournier", "J-D", "Fournier")]:
+        result = normalizer.normalize_text(raw)
+        assert result.outcome is PersonNameOutcome.PERSON
+        assert result.canonical_name is not None
+        assert result.canonical_name.normalized.given_name == given
+        assert result.canonical_name.normalized.surname == surname
+        assert result.dropped_tokens == ()
+    # a bare degree with no hyphen still drops
+    degree = normalizer.normalize_text("John Smith MA")
+    assert degree.canonical_name is not None
+    assert degree.canonical_name.text == "John Smith"
+
+
 def test_meng_surname_is_preserved_while_meng_degree_is_dropped(
     normalizer: PersonNameNormalizationService,
 ) -> None:


### PR DESCRIPTION
Two guards for leading credential-collision tokens in the non-Chinese person path, on top of #22 (0.4.2). Bumps 0.4.2 → 0.4.3.

Follow-up to @sergeyf's review question on #21 ("Keep credential-collision givens → how does it know when to keep vs not?"). The casing heuristic (Title-case ambiguous credential → keep as a name, to protect `Md`=Mohammad / `Ma`=María) had two gaps.

## Guard 1 — drop Title-case pure-credential prefixes before a complete name
`RN`/`JD`/`MBA`/`MPA`/`BS` in Title-case were kept as the given name when a full name followed (`Rn Rachael Zimlich` → given `Rn`, real given `Rachael` shoved to middle), because Title-case ambiguous credentials are read as names. These five keys have ~no real given-name use (unlike `Md`/`Ma`/`Do`/`Meng`/`Ba`/`Edd`), so a Title-case one before a complete name (≥2 following tokens, ≥1 non-initial) now drops. A bare surname after it (`Rn Cahn`) is left alone.

## Guard 2 — keep hyphenated leading initials
`M-A`/`M.-A.`/`J-D` are compound given-name initials, but their compact key collides with a degree (`ma`/`jd`/`ms`) and the form was dropped as a credential. A hyphen between single letters marks initials — no degree contains one — so the leading-credential drop is now guarded by a hyphen-initial pattern (consistent with the already-kept dotted `J.-D.`).

## Validation (0.4.2 vs 0.4.3, full 349k-name credential-collision population)
- **7,576 names / 11,490 occ change; 0 Chinese-detected** (fix is non-Chinese-path only, not shared with the Chinese pipeline).
- Guard 1: 7,105 names — blind-judged (3-judge majority, unanimous) **99.2% correct**, 0 real names dropped (2 non-person company strings).
- Guard 1 cascade (stacked creds, 225 names): **95%** correct.
- Guard 2: 246 names — blind-judged **100%** `keep_correct`, 0 degrees wrongly kept.
- No regressions: a degree never has a hyphen, and the excluded keys (`Md`/`Ma`/`Do`/`Meng`/`Ba`) are untouched, so Mohammad/María stay safe.

## Known limitations (out of scope, unchanged from 0.4.0)
- Bare all-caps `MA`=María (no hyphen) still drops as the MA degree — no signal to separate it from the degree.
- Guard 2 recovers ~66% of hyphenated-initial losses (246/373); `M-S`-style tokens in 3+ token names are dropped by a second path not covered here.

All 396 person-name tests pass.
